### PR TITLE
Add support for header file extensions

### DIFF
--- a/codelib/static/codebase/languages.py
+++ b/codelib/static/codebase/languages.py
@@ -38,6 +38,8 @@ EXTENSION_MAP: dict[str, IDXSupportedLanguage] = {
     "rs": "rust",
     "c": "c",
     "cpp": "cpp",
+    "h": "c",
+    "hpp": "cpp",
     "cs": "csharp",
     "go": "go",
     "ex": "elixir",


### PR DESCRIPTION
Add support for `.h` and `.hpp` header files to enable their parsing and analysis.