### PR TITLE
Add FILTER_DEPENDENCY_BY_LLM and Dependency Options in `coarse_recall_strategy`

### DIFF
--- a/coderetrx/retrieval/code_recall.py
+++ b/coderetrx/retrieval/code_recall.py
@@ -118,6 +118,7 @@ async def _multi_strategy_code_recall(
             - "filename": Uses FILTER_FILENAME_BY_LLM only
             - "symbol": Uses ADAPTIVE_FILTER_SYMBOL_BY_VECTOR_AND_LLM strategy
             - "line": Uses INTELLIGENT_FILTER strategy with line-level vector recall
+            - "dependency": Uses FILTER_DEPENDENCY_BY_LLM strategy
             - "auto": Uses LLM to determine best strategy based on prompt (chooses from filename, symbol, line)
             - "precise": Uses full LLM filtering/mapping (default behavior)
             - "custom": Uses the provided custom_strategies
@@ -146,6 +147,8 @@ async def _multi_strategy_code_recall(
         strategies_to_run = [RecallStrategy.ADAPTIVE_FILTER_SYMBOL_BY_VECTOR_AND_LLM]
     elif mode == "line":
         strategies_to_run = [RecallStrategy.INTELLIGENT_FILTER]
+    elif mode == "dependency":
+        strategies_to_run = [RecallStrategy.FILTER_DEPENDENCY_BY_LLM]
     elif mode == "auto":
         strategies = await _determine_strategy_by_llm(
             prompt=prompt,
@@ -283,7 +286,7 @@ async def coderetrx_mapping(
     prompt: str,
     subdirs_or_files: List[str],
     granularity: LLMMapFilterTargetType,
-    coarse_recall_strategy: Literal["filename", "symbol", "line", "auto", "custom"],
+    coarse_recall_strategy: Literal["filename", "symbol", "line", "auto", "custom", "dependency"],
     custom_strategies: List[RecallStrategy] = [],
     topic_extractor: Optional[TopicExtractor] = None,
     settings: Optional[CodeRecallSettings] = None,
@@ -330,7 +333,7 @@ async def coderetrx_filter(
     prompt: str,
     subdirs_or_files: List[str],
     granularity: LLMMapFilterTargetType,
-    coarse_recall_strategy: Literal["filename", "symbol", "line", "auto", "custom"],
+    coarse_recall_strategy: Literal["filename", "symbol", "line", "auto", "custom", "dependency"],
     custom_strategies: List[RecallStrategy] = [],
     topic_extractor: Optional[TopicExtractor] = None,
     settings: Optional[CodeRecallSettings] = None,

--- a/coderetrx/retrieval/strategies.py
+++ b/coderetrx/retrieval/strategies.py
@@ -26,7 +26,7 @@ from .smart_codebase import (
 )
 import random
 from .topic_extractor import TopicExtractor
-from coderetrx.static import Symbol, Keyword, File, CodeElement
+from coderetrx.static import Symbol, Keyword, File, CodeElement, Dependency
 from pathlib import Path
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -40,6 +40,7 @@ class RecallStrategy(Enum):
     FILTER_KEYWORD_BY_VECTOR = "filter_keywords_by_vector"
     FILTER_SYMBOL_BY_VECTOR = "filter_symbol_by_vector"
     FILTER_SYMBOL_BY_LLM = "filter_symbol_by_llm"
+    FILTER_DEPENDENCY_BY_LLM = "filter_dependency_by_llm"
     FILTER_KEYWORD_BY_VECTOR_AND_LLM = "filter_keyword_by_vector_and_llm"
     FILTER_SYMBOL_BY_VECTOR_AND_LLM = "filter_symbol_by_vector_and_llm"
     ADAPTIVE_FILTER_KEYWORD_BY_VECTOR_AND_LLM = "adaptive_filter_keyword_by_vector_and_llm"
@@ -782,6 +783,47 @@ class FilterSymbolByLLMStrategy(FilterByLLMStrategy[Symbol]):
         self, elements: List[Symbol], codebase: Codebase
     ) -> List[str]:
         return [str(symbol.file.path) for symbol in elements]
+
+
+class FilterDependencyByLLMStrategy(FilterByLLMStrategy[Dependency]):
+    """Strategy to filter dependencies by LLM and retrieve code chunks that use these dependencies."""
+
+    @override
+    def get_strategy_name(self) -> str:
+        return "FILTER_DEPENDENCY_BY_LLM"
+
+    @override
+    def get_target_type(self) -> LLMMapFilterTargetType:
+        return "dependency_name"
+
+    @override
+    def extract_file_paths(
+        self, elements: List[Dependency], codebase: Codebase
+    ) -> List[str]:
+        """Extract file paths from dependencies by getting files that import these dependencies."""
+        file_paths = set()
+        for dependency in elements:
+            if isinstance(dependency, Dependency) and dependency.imported_by:
+                for imported_file in dependency.imported_by:
+                    file_paths.add(str(imported_file.path))
+        return list(file_paths)
+
+    @override
+    async def execute(
+        self, codebase: Codebase, prompt: str, subdirs_or_files: List[str]
+    ) -> Tuple[List[str], List[Any]]:
+        enhanced_prompt = f"""
+        A dependency that matches the following criteria is highly likely to be relevant:
+        <dependency_criteria>
+        {prompt}
+        </dependency_criteria>
+        <note>
+        The objective is to identify dependencies based on their names that match the specified criteria.
+        Files that import these matching dependencies will be retrieved for further analysis.
+        Focus on dependency names, package names, module names, and library names that are relevant to the criteria.
+        </note>
+        """
+        return await super().execute(codebase, enhanced_prompt, subdirs_or_files)
 
 
 class FilterKeywordByVectorStrategy(FilterByVectorStrategy[Keyword]):
@@ -1598,6 +1640,7 @@ class StrategyFactory:
             RecallStrategy.FILTER_KEYWORD_BY_VECTOR: FilterKeywordByVectorStrategy,
             RecallStrategy.FILTER_SYMBOL_BY_VECTOR: FilterSymbolByVectorStrategy,
             RecallStrategy.FILTER_SYMBOL_BY_LLM: FilterSymbolByLLMStrategy,
+            RecallStrategy.FILTER_DEPENDENCY_BY_LLM: FilterDependencyByLLMStrategy,
             RecallStrategy.FILTER_KEYWORD_BY_VECTOR_AND_LLM: FilterKeywordByVectorAndLLMStrategy,
             RecallStrategy.FILTER_SYMBOL_BY_VECTOR_AND_LLM: FilterSymbolByVectorAndLLMStrategy,
             RecallStrategy.ADAPTIVE_FILTER_KEYWORD_BY_VECTOR_AND_LLM: AdaptiveFilterKeywordByVectorAndLLMStrategy,


### PR DESCRIPTION
This PR introduces the following changes:  

1. **New Strategy - `FILTER_DEPENDENCY_BY_LLM`**:  
   - Adds a new strategy, `FILTER_DEPENDENCY_BY_LLM`, which utilizes LLMs to filter dependencies and retrieve relevant code chunks that use these dependencies.  

2. **Enhancement to `coarse_recall_strategy`**:  
   - Adds a new `dependency` option to the `coarse_recall_strategy` function.  
   - Improves the flexibility of the strategy by allowing dependencies to be considered during coarse recall.

These changes aim to improve code chunk filtering accuracy and provide additional options for dependency analysis. 