### PR TITLE
Add an option to enable use coarse recall returned elements to pefrom refined filter

### DIFF
--- a/coderetrx/impl/default/factory.py
+++ b/coderetrx/impl/default/factory.py
@@ -71,8 +71,8 @@ class SmartCodebaseSettings(BaseSettings):
     )
     symbol_codeline_embedding: bool = Field(
         default=False,
-        description="Enable symbol conline embeddings",
-        alias="SYMBOL_CONLINE_EMBEDDING",
+        description="Enable symbol codeline embeddings",
+        alias="SYMBOL_CODELINE_EMBEDDING",
     )
 @define
 class CodebaseFactory:
@@ -180,22 +180,38 @@ class CodebaseFactory:
                 "Keyword embeddings feature is not enabled (KEYWORD_EMBEDDING not set), keyword searcher not initialized"
             )
         if settings.symbol_codeline_embedding:
+            # Collect all lines from all symbols with metadata
+            all_lines = []
+            all_metadatas = []
+            
             for symbol in codebase.symbols:
                 if symbol.chunk:
                     try:
                         logger.info(
-                            f"Initializing symbol codeline searcher for symbol {symbol.id}"
+                            f"Collecting lines for symbol {symbol.id}"
                         )
                         lines = symbol.chunk.code().split("\n")
-                        codebase.symbol_codeline_searcher[symbol.id] = SimilaritySearcher(
-                            f"{codebase.id}_symbol_codelines_{symbol.id}",
-                            lines,
-                        )
-
+                        for line in lines:
+                            all_lines.append(line)
+                            all_metadatas.append({"symbol_id": symbol.id})
+                        
                         logger.info(
-                            f"Symbol codeline searcher for symbol {symbol.id} initialized successfully"
+                            f"Collected {len(lines)} lines for symbol {symbol.id}"
                         )
                     except Exception as e:
                         logger.error(
-                            f"Failed to initialize symbol codeline searcher for symbol {symbol.id}: {e}"
+                            f"Failed to collect lines for symbol {symbol.id}: {e}"
                         )
+            
+            # Create single collection for all lines with metadata
+            if all_lines:
+                try:
+                    logger.info(f"Creating unified codeline searcher with {len(all_lines)} total lines")
+                    codebase.symbol_codeline_searcher = SimilaritySearcher(
+                        f"{codebase.id}_symbol_codelines",
+                        all_lines,
+                        metadatas=all_metadatas
+                    )
+                    logger.info("Unified symbol codeline searcher initialized successfully")
+                except Exception as e:
+                    logger.error(f"Failed to initialize unified symbol codeline searcher: {e}")

--- a/coderetrx/impl/default/factory.py
+++ b/coderetrx/impl/default/factory.py
@@ -65,10 +65,15 @@ class SmartCodebaseSettings(BaseSettings):
         description="Enable symbol content embeddings",
         alias="SYMBOL_CONTENT_EMBEDDING",
     )
+
     keyword_embedding: bool = Field(
         default=False, description="Enable keyword embeddings", alias="KEYWORD_EMBEDDING"
     )
-
+    symbol_codeline_embedding: bool = Field(
+        default=False,
+        description="Enable symbol conline embeddings",
+        alias="SYMBOL_CONLINE_EMBEDDING",
+    )
 @define
 class CodebaseFactory:
     @classmethod
@@ -174,3 +179,23 @@ class CodebaseFactory:
             logger.info(
                 "Keyword embeddings feature is not enabled (KEYWORD_EMBEDDING not set), keyword searcher not initialized"
             )
+        if settings.symbol_codeline_embedding:
+            for symbol in codebase.symbols:
+                if symbol.chunk:
+                    try:
+                        logger.info(
+                            f"Initializing symbol codeline searcher for symbol {symbol.id}"
+                        )
+                        lines = symbol.chunk.code().split("\n")
+                        codebase.symbol_codeline_searcher[symbol.id] = SimilaritySearcher(
+                            f"{codebase.id}_symbol_codelines_{symbol.id}",
+                            lines,
+                        )
+
+                        logger.info(
+                            f"Symbol codeline searcher for symbol {symbol.id} initialized successfully"
+                        )
+                    except Exception as e:
+                        logger.error(
+                            f"Failed to initialize symbol codeline searcher for symbol {symbol.id}: {e}"
+                        )

--- a/coderetrx/impl/default/prompt.py
+++ b/coderetrx/impl/default/prompt.py
@@ -150,12 +150,6 @@ return a JSONObject that contains:
 ).strip()
 
 
-class CodeMapFilterResult(BaseModel):
-    index: int
-    reason: str
-    result: Any
-
-
 class KeywordExtractorResult(BaseModel):
     reason: str
     result: str

--- a/coderetrx/impl/default/smart_codebase.py
+++ b/coderetrx/impl/default/smart_codebase.py
@@ -2,6 +2,7 @@ from typing import Optional, List, Tuple, Any, Union, Literal, TYPE_CHECKING
 from coderetrx.static import Codebase, Dependency
 from coderetrx.static.codebase import Symbol, Keyword, File, CodeLine
 from coderetrx.retrieval import SmartCodebase as SmartCodebaseBase, LLMCallMode
+from coderetrx.retrieval.smart_codebase import CodeMapFilterResult
 from attrs import define, field
 from coderetrx.utils.embedding import SimilaritySearcher
 import os
@@ -17,7 +18,6 @@ from .prompt import (
     filter_and_mapping_function_call_user_prompt_template,
     get_filter_function_definition,
     get_mapping_function_definition,
-    CodeMapFilterResult,
 )
 from tqdm.asyncio import tqdm
 import asyncio
@@ -52,9 +52,8 @@ class SmartCodebase(SmartCodebaseBase):
     symbol_name_searcher: Optional["SimilaritySearcher"] = field(default=None)
     symbol_content_searcher: Optional["SimilaritySearcher"] = field(default=None)
     keyword_searcher: Optional["SimilaritySearcher"] = field(default=None)
-    # each symbol will has a codeline searcher, which is a similarity searcher for the symbol's code line
-    # symbol_id -> SimilaritySearcher
-    symbol_codeline_searcher: Optional[dict[str, "SimilaritySearcher"]] = field(default_factory=dict)
+    # unified codeline searcher for all symbols with metadata filtering
+    symbol_codeline_searcher: Optional["SimilaritySearcher"] = field(default=None)
     settings: "SmartCodebaseSettings" = field(factory=get_smart_codebase_settings)
 
     def _get_filtered_elements(
@@ -603,18 +602,70 @@ class SmartCodebase(SmartCodebaseBase):
             elif search_type == "symbol_codeline":
                 if self.symbol_codeline_searcher is None:
                     raise ValueError("Symbol codeline searcher is not initialized")
-                symbol_by_id = {symbol.id: symbol for symbol in self.symbols} 
-                for symbol_id, searcher in self.symbol_codeline_searcher.items():
-                        # Search for matching lines in this symbol
-                    for doc, score in searcher.search(query, top_k):
-                        if score >= threshold:
-                            results.append(
-                                CodeLine.new(
-                                    symbol=symbol_by_id[symbol_id],
-                                    content=doc,
-                                    score=score
-                                )
-                            )
+                symbol_by_id = {symbol.id: symbol for symbol in self.symbols}
                 
+                # Search all lines with no filtering (get all matching lines across symbols)
+                for doc, score in self.symbol_codeline_searcher.search(query, top_k):
+                    if score >= threshold:
+                        # Since we don't have metadata in the basic search, we need to find which symbol this line belongs to
+                        # This is a fallback approach - we'll need to enhance this with metadata search
+                        for symbol in self.symbols:
+                            if symbol.chunk and doc in symbol.chunk.code():
+                                results.append(
+                                    CodeLine.new(
+                                        line_content=doc,
+                                        symbol=symbol,
+                                        score=score
+                                    )
+                                )
+                                break
+                
+
+        return results
+
+    def search_symbol_lines(self, symbol_id: str, query: str, threshold: Optional[float] = None, top_k: int = 10) -> List[Any]:
+        """
+        Search for similar lines within a specific symbol using metadata filtering.
+
+        Args:
+            symbol_id: The ID of the symbol to search within
+            query: The search query
+            threshold: Similarity threshold, defaults to value from environment variable
+            top_k: Maximum number of results to return
+
+        Returns:
+            List of CodeLine objects that match the search criteria within the specified symbol
+
+        Raises:
+            ValueError: If symbol codeline searcher is not initialized
+        """
+        if self.symbol_codeline_searcher is None:
+            raise ValueError("Symbol codeline searcher is not initialized")
+
+        threshold = (
+            self.settings.similarity_search_threshold
+            if threshold is None
+            else threshold
+        )
+
+        symbol_by_id = {symbol.id: symbol for symbol in self.symbols}
+        if symbol_id not in symbol_by_id:
+            return []
+
+        symbol = symbol_by_id[symbol_id]
+        results = []
+
+        # Use metadata filtering to search only within the specified symbol
+        for doc, score in self.symbol_codeline_searcher.search_with_filter(
+            query, where={"symbol_id": symbol_id}, k=top_k
+        ):
+            if score >= threshold:
+                results.append(
+                    CodeLine.new(
+                        line_content=doc,
+                        symbol=symbol,
+                        score=score
+                    )
+                )
 
         return results

--- a/coderetrx/retrieval/smart_codebase.py
+++ b/coderetrx/retrieval/smart_codebase.py
@@ -3,6 +3,8 @@ from coderetrx.static import Codebase, Keyword, Symbol, File
 from typing import Literal, List, Tuple, Any, Union, Optional
 from pydantic import BaseModel
 
+from coderetrx.static.codebase.codebase import CodeLine
+
 LLMMapFilterTargetType = Literal[
     "file_name",
     "file_content",
@@ -63,5 +65,5 @@ class SmartCodebase(Codebase, ABC):
         query: str,
         threshold: Optional[float] = None,
         top_k: int = 100,
-    ) -> List[Symbol | Keyword]:
+    ) -> List[Symbol | Keyword | CodeLine]:
         pass

--- a/coderetrx/retrieval/strategies.py
+++ b/coderetrx/retrieval/strategies.py
@@ -51,6 +51,8 @@ class RecallStrategy(Enum):
 
 
 class StrategyExecuteResult(BaseModel):
+    model_config = {"arbitrary_types_allowed": True}
+    
     file_paths: List[str] = Field(description="List of file paths returned by the strategy")
     elements: List[CodeElement] = Field(description="List of code elements returned by the strategy")
     llm_results: List[CodeMapFilterResult] = Field(description="List of LLM results returned by the strategy")

--- a/coderetrx/retrieval/strategies.py
+++ b/coderetrx/retrieval/strategies.py
@@ -27,6 +27,7 @@ from .smart_codebase import (
 import random
 from .topic_extractor import TopicExtractor
 from coderetrx.static import Symbol, Keyword, File, CodeElement, Dependency
+from coderetrx.static.codebase import CodeLine
 from pathlib import Path
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -469,7 +470,7 @@ class FilterByVectorAndLLMStrategy(RecallStrategyExecutor, ABC):
     @abstractmethod
     def get_target_types_for_vector(
         self,
-    ) -> List[Literal["symbol_name", "symbol_content", "keyword"]]:
+    ) -> List[Literal["symbol_name", "symbol_content", "keyword", "symbol_codeline"]]:
         """Return the target types for similarity search."""
         pass
 
@@ -634,7 +635,7 @@ class AdaptiveFilterByVectorAndLLMStrategy(RecallStrategyExecutor, ABC):
     @abstractmethod
     def get_target_types_for_vector(
         self,
-    ) -> List[Literal["symbol_name", "symbol_content", "keyword"]]:
+    ) -> List[Literal["symbol_name", "symbol_content", "keyword", "symbol_codeline"]]:
         """Return the target types for similarity search."""
         pass
 
@@ -1286,38 +1287,14 @@ class AdaptiveFilterSymbolByVectorAndLLMStrategy(AdaptiveFilterByVectorAndLLMStr
         return await super().execute(codebase, prompt, subdirs_or_files)
 
 
-class RecalledLineEntry(BaseModel):
-    """Pydantic model representing a recalled line entry with metadata."""
-    line_content: str = Field(description="The content of the recalled line")
-    symbol: Symbol = Field(description="Symbol object containing this line")
-    score: float = Field(description="Vector similarity score for this line")
-
-
-class VectorLineRecallResult(BaseModel):
-    """Pydantic model representing the result of manual vector recall."""
-    line_content: str = Field(description="The content of the recalled line")
-    line_index: int = Field(description="The original line index in the symbol")
-    similarity_score: float = Field(description="The normalized similarity score")
-
-
-@define
-class SymbolStruct:
-    """Structure to represent a symbol and its metadata for intelligent filtering."""
-    vectors: List[Any]       # Embeddings of the symbol lines
-    symbol: Symbol           # The original symbol object
-    lines: List[str]         # Individual lines of the symbol
-    symbol_id: str           # Unique identifier for the symbol
-    file_path: str           # File path for the symbol
-
-
 class FilterTopkLineByVectorAndLLMStrategy(RecallStrategyExecutor):
     """
-    Intelligent filtering strategy that performs line-level vector recall within symbols,
+    Intelligent filtering strategy that performs line-level vector recall using builtin codeline searcher,
     then uses LLM to judge and select the most relevant lines across all symbols.
     """
     
     def __init__(self, 
-                 top_k_per_symbol: int = 5,
+                 top_k: int = 1000,
                  max_queries: int = 20,
                  topic_extractor: Optional[TopicExtractor] = None, 
                  llm_call_mode: LLMCallMode = "traditional"):
@@ -1325,172 +1302,18 @@ class FilterTopkLineByVectorAndLLMStrategy(RecallStrategyExecutor):
         Initialize the intelligent filtering strategy.
         
         Args:
-            top_k_per_symbol: Number of top lines to recall per symbol (default: 5)
-            max_queries: Maximum number of LLM queries allowed (default: 100)
+            top_k: Number of top lines to recall from builtin searcher (default: 1000)
+            max_queries: Maximum number of LLM queries allowed (default: 20)
             topic_extractor: Optional TopicExtractor instance
             llm_call_mode: Mode for LLM calls
         """
         super().__init__(topic_extractor=topic_extractor, llm_call_mode=llm_call_mode)
-        self.top_k_per_symbol = top_k_per_symbol
+        self.top_k = top_k
         self.max_queries = max_queries
     
     def get_strategy_name(self) -> str:
         return "INTELLIGENT_FILTER"
     
-    async def _generate_line_embeddings(self, lines: List[str]) -> List[Any]:
-        """Generate embeddings for individual lines using cached embedder."""
-        from coderetrx.utils.embedding import cached_embedder
-        from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
-        
-        filtered_lines = [line.strip() for line in lines if line.strip() and len(line.strip()) > 3]
-        if not filtered_lines:
-            return []
-        
-        @retry(
-            stop=stop_after_attempt(5),
-            wait=wait_exponential(min=30, max=600),
-            retry=retry_if_exception_type(Exception),
-        )
-        async def _embed_lines_with_retry():
-            """Embed lines using cached embedder."""
-            try:
-                # Use cached embedder instead of direct create_documents_embedding
-                embeddings = await cached_embedder.aembed_documents(filtered_lines)
-                return embeddings
-            except Exception as e:
-                logger.warning(f"Line embedding batch failed, will retry: {str(e)}")
-                raise
-        
-        try:
-            embeddings = await _embed_lines_with_retry()
-            logger.debug(f"Successfully generated {len(embeddings)} embeddings for {len(filtered_lines)} lines")
-            return embeddings
-        except Exception as e:
-            logger.error(f"All retry attempts failed for line embeddings: {e}")
-            return []
-    
-    async def _vector_recall_topk(self, func_struct: SymbolStruct, query: str, k: int) -> List[VectorLineRecallResult]:
-        """
-        Perform vector-based top-k recall for lines within a function using in-memory computation.
-        
-        Args:
-            func_struct: Function structure containing vectors and lines
-            query: Query text for similarity search
-            k: Number of top lines to return
-            
-        Returns:
-            List of ManualVectorRecallResult objects
-        """
-        if not func_struct.vectors or not func_struct.lines:
-            return []
-        
-        return await self._manual_vector_recall(func_struct, query, k)
-    
-    async def _manual_vector_recall(self, func_struct: SymbolStruct, query: str, k: int) -> List[VectorLineRecallResult]:
-        """
-        Fallback manual vector recall using numpy operations.
-        """
-        try:
-            from coderetrx.utils.embedding import create_documents_embedding
-            import numpy as np
-            
-            # Generate query embedding using robust utilities
-            query_embedding = create_documents_embedding([query])
-            if not query_embedding:
-                return []
-            
-            query_vec = np.array(query_embedding[0])
-            line_vecs = np.array(func_struct.vectors)
-            
-            # Calculate cosine similarities with proper normalization
-            query_norm = query_vec / np.linalg.norm(query_vec)
-            line_norms = line_vecs / np.linalg.norm(line_vecs, axis=1, keepdims=True)
-            
-            similarities = np.dot(line_norms, query_norm)
-            top_indices = np.argsort(similarities)[-k:][::-1]
-            
-            results = []
-            filtered_lines = [line.strip() for line in func_struct.lines if line.strip() and len(line.strip()) > 3]
-            
-            for idx in top_indices:
-                if idx < len(filtered_lines):
-                    # Find original line index
-                    filtered_line = filtered_lines[idx]
-                    original_idx = -1
-                    for i, original_line in enumerate(func_struct.lines):
-                        if original_line.strip() == filtered_line:
-                            original_idx = i
-                            break
-
-                    if original_idx >= 0:
-                        normalized_score = (similarities[idx] + 1) / 2
-                        results.append(VectorLineRecallResult(
-                            line_content=filtered_line,
-                            line_index=original_idx,
-                            similarity_score=normalized_score
-                        ))
-            
-            return results
-            
-        except Exception as e:
-            logger.error(f"Error in manual vector recall for symbol {func_struct.symbol_id}: {e}")
-            return []
-    
-    async def _prepare_symbol_structures(self, symbols: List[Symbol], subdirs_or_files: List[str]) -> List[SymbolStruct]:
-        """
-        Prepare symbol structures with line-level embeddings.
-        
-        Args:
-            symbols: List of symbols to process
-            subdirs_or_files: List of subdirectories or files to filter by
-            
-        Returns:
-            List of SymbolStruct objects with embeddings
-        """
-        from tqdm import tqdm
-        
-        symbol_structs = []
-        
-        # Progress bar for symbol processing
-        with tqdm(total=len(symbols), desc="Processing symbols for intelligent filtering", unit="symbol") as pbar:
-            for symbol in symbols:
-                try:
-                    # Filter by subdirectories if specified
-                    file_path = str(symbol.file.path)
-                    if subdirs_or_files and not any(file_path.startswith(subdir) for subdir in subdirs_or_files):
-                        pbar.update(1)
-                        continue
-                    
-                    # Get symbol lines
-                    lines = symbol.chunk.lines()
-                    if not lines:
-                        pbar.update(1)
-                        continue
-                    
-                    # Generate embeddings for lines using existing utilities
-                    vectors = await self._generate_line_embeddings(lines)
-                    if not vectors:
-                        pbar.update(1)
-                        continue
-                    
-                    # Create function structure
-                    symbol_struct = SymbolStruct(
-                        vectors=vectors,
-                        symbol=symbol,
-                        lines=lines,
-                        symbol_id=symbol.id or f"{symbol.name}_{symbol.file.path}",
-                        file_path=file_path
-                    )
-                    
-                    symbol_structs.append(symbol_struct)
-                    
-                except Exception as e:
-                    logger.error(f"Error preparing symbol structure for {symbol.name}: {e}")
-                finally:
-                    pbar.update(1)
-        
-        logger.info(f"Prepared {len(symbol_structs)} symbol structures for intelligent filtering")
-        return symbol_structs
     
     async def _llm_recall_judgment(self, line_candidates: List[Tuple[str, str, str]], query: str) -> List[str]:
         """
@@ -1597,9 +1420,9 @@ Call the select_relevant_lines function with your analysis."""
             # Fallback: return first few candidates from this batch
             return [candidate[0] for candidate in line_candidates[:3]]
     
-    async def execute(self, codebase: Codebase, prompt: str, subdirs_or_files: List[str]) -> Tuple[List[str], List[Any]]:
+    async def execute(self, codebase: Codebase, prompt: str, subdirs_or_files: List[str]) -> StrategyExecuteResult:
         """
-        Execute the intelligent filter strategy with optimized batch processing.
+        Execute the intelligent filter strategy using builtin codeline searcher.
         
         Args:
             codebase: The codebase to search in
@@ -1607,10 +1430,10 @@ Call the select_relevant_lines function with your analysis."""
             subdirs_or_files: List of subdirectories or files to process
             
         Returns:
-            Tuple of (file_paths, llm_results)
+            StrategyExecuteResult containing file_paths, elements, and llm_results
         """
         strategy_name = self.get_strategy_name()
-        logger.info(f"Using {strategy_name} strategy")
+        logger.info(f"Using {strategy_name} strategy with builtin codeline searcher")
         
         try:
             # Extract topic for vector search
@@ -1626,52 +1449,47 @@ Call the select_relevant_lines function with your analysis."""
             else:
                 logger.info(f"Using extracted topic '{topic}' for intelligent filtering")
             
-            # Step 1: Get all symbols and prepare structures with embeddings
-            print("Entering Step 1 - Preparing symbol structures")
-            all_symbols = codebase.symbols
-            filtered_symbols = self.filter_elements_by_subdirs(all_symbols, codebase, subdirs_or_files)
-
-            logger.info(f"Processing {len(filtered_symbols)} symbols for intelligent filtering")
+            # Step 1: Use builtin codeline searcher to get line-level results
+            logger.info("Step 1 - Using builtin codeline searcher for line-level vector recall")
             
-            symbol_structs = await self._prepare_symbol_structures(filtered_symbols, subdirs_or_files)
+            # Use the builtin similarity_search with symbol_codeline target type
+            all_recalled_lines:list[CodeLine] = await codebase.similarity_search(
+                target_types=["symbol_codeline"],
+                query=topic,
+                threshold=0,
+                top_k=self.top_k,
+            )
             
-            if not symbol_structs:
-                logger.info("No symbols found for intelligent filtering")
-                return [], []
-            
-            # Step 2: Perform vector-based recall for each symbol and sort by similarity
-            all_recalled_lines: List[RecalledLineEntry] = []
-            print("Entering Step 2 - Vector recall for symbols")
-            for symbol_struct in symbol_structs:
-                recalled_lines = await self._vector_recall_topk(
-                    symbol_struct, topic, self.top_k_per_symbol
-                )
-                
-                if recalled_lines:
-                    # Store line candidates with metadata
-                    for line_content, line_idx, score in recalled_lines:
-                        all_recalled_lines.append(RecalledLineEntry(
-                            line_content=line_content,
-                            symbol=symbol_struct.symbol,
-                            score=score
-                        ))
-            
-            logger.info(f"Collected {len(all_recalled_lines)} line candidates from vector recall")
+            logger.info(f"Builtin codeline searcher found {len(all_recalled_lines)} line candidates")
             
             if not all_recalled_lines:
-                logger.info("No lines recalled from vector search")
-                return [], []
+                logger.info("No lines recalled from builtin codeline searcher")
+                return StrategyExecuteResult(
+                    file_paths=[],
+                    elements=[],
+                    llm_results=[]
+                )
             
-            # Sort by vector similarity score (descending)
+            # Filter by subdirectories if specified
+            if subdirs_or_files:
+                filtered_lines = []
+                for code_line in all_recalled_lines:
+                    file_path = str(code_line.symbol.file.path)
+                    if any(file_path.startswith(subdir) for subdir in subdirs_or_files):
+                        filtered_lines.append(code_line)
+                all_recalled_lines = filtered_lines
+                logger.info(f"Filtered to {len(all_recalled_lines)} lines from specified subdirectories")
+            
+            # Sort by vector similarity score (descending) - CodeLine objects should have score attribute
             all_recalled_lines.sort(key=lambda x: x.score, reverse=True)
             logger.info("Sorted line candidates by vector similarity score")
             
-            # Step 3: Optimized LLM processing with dynamic batch evaluation
-            print("Entering Step 3 - Dynamic batch processing")
+            # Step 2: LLM processing with dynamic batch evaluation
+            logger.info("Step 2 - LLM processing with dynamic batch evaluation")
             selected_file_paths = set()
             recalled_symbols = [] 
             recalled_symbol_ids = set()
-            batch_size = 120
+            batch_size = 30  # Smaller batch size for better LLM processing
             
             # Process candidates in dynamic batches
             current_index = 0
@@ -1683,7 +1501,7 @@ Call the select_relevant_lines function with your analysis."""
             with tqdm(total=self.max_queries, desc="LLM batch queries", unit="query") as pbar:
                 while current_index < len(all_recalled_lines) and query_count < self.max_queries:
                     # Collect next batch of valid candidates
-                    batch_candidates:list[RecalledLineEntry] = []
+                    batch_candidates = []
                     
                     while len(batch_candidates) < batch_size and current_index < len(all_recalled_lines):
                         entry = all_recalled_lines[current_index]
@@ -1717,6 +1535,7 @@ Call the select_relevant_lines function with your analysis."""
                     # Mark selected symbols as recalled
                     for selected_line in selected_lines:
                         for entry in batch_candidates:
+                            symbol_id = entry.symbol.id or f"{entry.symbol.name}_{entry.symbol.file.path}"
                             file_path = str(entry.symbol.file.path)
                             if entry.line_content == selected_line and symbol_id not in recalled_symbol_ids:
                                 recalled_symbols.append(entry.symbol)
@@ -1728,7 +1547,6 @@ Call the select_relevant_lines function with your analysis."""
                     logger.info(f"Processed batch {batch_count}: Selected {len(selected_lines)} symbols from {len(batch_candidates)} candidates")
             
             file_paths = list(selected_file_paths)
-            print(f"Total selected file paths: {len(file_paths)}")
             logger.info(f"Intelligent filtering completed. Selected {len(file_paths)} files from {len(recalled_symbols)} symbols.")
             
             return StrategyExecuteResult(

--- a/coderetrx/retrieval/strategies.py
+++ b/coderetrx/retrieval/strategies.py
@@ -32,6 +32,7 @@ from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from os import PathLike
 from attrs import define
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -45,9 +46,14 @@ class RecallStrategy(Enum):
     FILTER_SYMBOL_BY_VECTOR_AND_LLM = "filter_symbol_by_vector_and_llm"
     ADAPTIVE_FILTER_KEYWORD_BY_VECTOR_AND_LLM = "adaptive_filter_keyword_by_vector_and_llm"
     ADAPTIVE_FILTER_SYMBOL_BY_VECTOR_AND_LLM = "adaptive_filter_symbol_by_vector_and_llm"
-    INTELLIGENT_FILTER = "intelligent_filter"
+    FILTER_TOPK_LINE_BY_VECTOR_AND_LLM = "intelligent_filter"
 
 
+class StrategyExecuteResult(BaseModel):
+    file_paths: List[str] = Field(description="List of file paths returned by the strategy")
+    elements: List[CodeElement] = Field(description="List of code elements returned by the strategy")
+    llm_results: List[CodeMapFilterResult] = Field(description="List of LLM results returned by the strategy")
+    
 class CodeRecallSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file_encoding="utf-8", env_file=".env", extra="allow"
@@ -199,7 +205,7 @@ IMPORTANT: Try to select only ONE element type if possible. Only select multiple
             if element_type == "FILENAME":
                 strategies.append(RecallStrategy.FILTER_FILENAME_BY_LLM)
             elif element_type == "LINE":
-                strategies.append(RecallStrategy.INTELLIGENT_FILTER)
+                strategies.append(RecallStrategy.FILTER_TOPK_LINE_BY_VECTOR_AND_LLM)
             elif element_type == "SYMBOL":
                 strategies.append(RecallStrategy.ADAPTIVE_FILTER_SYMBOL_BY_VECTOR_AND_LLM)
             elif element_type == "DEPENDENCY":
@@ -220,6 +226,48 @@ IMPORTANT: Try to select only ONE element type if possible. Only select multiple
 
 def rel_path(a: PathLike, b: PathLike) -> str:
     return str(Path(a).relative_to(Path(b)))
+
+def deduplicate_elements(elements: List[CodeElement]) -> List[CodeElement]:
+    """
+    Deduplicate elements by their id attribute.
+    
+    Args:
+        elements: List of code elements to deduplicate
+        
+    Returns:
+        List of deduplicated code elements, preserving order of first occurrence
+    """
+    if not elements:
+        return elements
+    
+    seen_ids: Set[str] = set()
+    deduplicated_elements: List[CodeElement] = []
+    
+    for element in elements:
+        # Get element id, fallback to a generated id if not available
+        element_id = getattr(element, 'id', None)
+        if element_id is None:
+            # Generate fallback id based on element type and attributes
+            if hasattr(element, 'name') and hasattr(element, 'file'):
+                element_id = f"{element.name}_{element.file.path}"
+            elif hasattr(element, 'path'):
+                element_id = str(element.path)
+            else:
+                # Last resort: use object id
+                element_id = str(id(element))
+        
+        if element_id not in seen_ids:
+            seen_ids.add(element_id)
+            deduplicated_elements.append(element)
+        else:
+            logger.debug(f"Deduplicated element with id: {element_id}")
+    
+    if len(deduplicated_elements) < len(elements):
+        logger.info(f"Deduplicated {len(elements) - len(deduplicated_elements)} elements, "
+                    f"keeping {len(deduplicated_elements)} unique elements")
+    
+    return deduplicated_elements
+
 
 
 class RecallStrategyExecutor(ABC):
@@ -269,7 +317,7 @@ class RecallStrategyExecutor(ABC):
     @abstractmethod
     async def execute(
         self, codebase: Any, prompt: str, subdirs_or_files: List[str]
-    ) -> Tuple[List[str], List[Any]]:
+    ) -> StrategyExecuteResult:
         """
         Execute the recall strategy.
 
@@ -279,7 +327,7 @@ class RecallStrategyExecutor(ABC):
             subdirs_or_files: List of subdirectories or files to process
 
         Returns:
-            Tuple of (file_paths, llm_results)
+            StrategyExecuteResult containing file_paths, elements, and llm_results
         """
         pass
 
@@ -306,7 +354,7 @@ class FilterByLLMStrategy(RecallStrategyExecutor, Generic[CodeElement], ABC):
 
     async def execute(
         self, codebase: Codebase, prompt: str, subdirs_or_files: List[str]
-    ) -> Tuple[List[str], List[Any]]:
+    ) -> StrategyExecuteResult:
         strategy_name = self.get_strategy_name()
         logger.info(f"Using {strategy_name} strategy")
         try:
@@ -317,7 +365,11 @@ class FilterByLLMStrategy(RecallStrategyExecutor, Generic[CodeElement], ABC):
                 elements, codebase, subdirs_or_files
             )
             file_paths = self.extract_file_paths(elements, codebase)
-            return list(set(file_paths)), llm_results
+            return StrategyExecuteResult(
+                file_paths=list(set(file_paths)),
+                elements=deduplicate_elements(elements),
+                llm_results=llm_results
+            )
         except Exception as e:
             logger.error(f"Error in {strategy_name} strategy: {e}")
             raise e
@@ -353,7 +405,7 @@ class FilterByVectorStrategy(RecallStrategyExecutor, Generic[CodeElement], ABC):
         codebase: Codebase,
         prompt: str,
         subdirs_or_files: List[str],
-    ) -> Tuple[List[str], List[Any]]:
+    ) -> StrategyExecuteResult:
         strategy_name = self.get_strategy_name()
         logger.info(f"Using {strategy_name} strategy")
         try:
@@ -396,7 +448,11 @@ class FilterByVectorStrategy(RecallStrategyExecutor, Generic[CodeElement], ABC):
                 elements = filtered_elements
 
             file_paths = self.extract_file_paths(elements, codebase, subdirs_or_files)
-            return file_paths, []
+            return StrategyExecuteResult(
+                file_paths=file_paths,
+                elements=deduplicate_elements(elements),
+                llm_results=[]
+            )
         except Exception as e:
             logger.error(f"Error in {strategy_name} strategy: {e}")
             raise e
@@ -462,7 +518,7 @@ class FilterByVectorAndLLMStrategy(RecallStrategyExecutor, ABC):
         codebase: Codebase,
         prompt: str,
         subdirs_or_files: List[str],
-    ) -> Tuple[List[str], List[Any]]:
+    ) -> StrategyExecuteResult:
         strategy_name = self.get_strategy_name()
         logger.info(f"Using {strategy_name} strategy")
         try:
@@ -510,7 +566,11 @@ class FilterByVectorAndLLMStrategy(RecallStrategyExecutor, ABC):
                 logger.info(
                     f"No elements found by vector search, returning empty result"
                 )
-                return [], []
+                return StrategyExecuteResult(
+                    file_paths=[],
+                    elements=[],
+                    llm_results=[]
+                )
 
             # Use LLM to filter the elements
             refined_elements, llm_results = await codebase.llm_filter(
@@ -528,7 +588,11 @@ class FilterByVectorAndLLMStrategy(RecallStrategyExecutor, ABC):
                 refined_elements, codebase, subdirs_or_files
             )
 
-            return list(set(file_paths)), llm_results
+            return StrategyExecuteResult(
+                file_paths=list(set(file_paths)),
+                elements=deduplicate_elements(refined_elements),
+                llm_results=llm_results
+            )
         except Exception as e:
             logger.error(f"Error in {strategy_name} strategy: {e}")
             raise e
@@ -724,7 +788,7 @@ class AdaptiveFilterByVectorAndLLMStrategy(RecallStrategyExecutor, ABC):
         codebase: Codebase,
         prompt: str,
         subdirs_or_files: List[str],
-    ) -> Tuple[List[str], List[Any]]:
+    ) -> StrategyExecuteResult:
         strategy_name = self.get_strategy_name()
         logger.info(f"Using {strategy_name} strategy")
         try:
@@ -748,7 +812,11 @@ class AdaptiveFilterByVectorAndLLMStrategy(RecallStrategyExecutor, ABC):
             # Perform adaptive retrieval (includes both vector search and LLM filtering)
             file_paths, llm_results = await self.adaptive_retrieval(codebase, prompt, topic, subdirs_or_files)
 
-            return file_paths, llm_results
+            return StrategyExecuteResult(
+                file_paths=file_paths,
+                elements=[],  # Adaptive strategies don't return elements directly
+                llm_results=llm_results
+            )
         except Exception as e:
             logger.error(f"Error in {strategy_name} strategy: {e}")
             raise e
@@ -772,7 +840,7 @@ class FilterFilenameByLLMStrategy(FilterByLLMStrategy[File]):
     @override
     async def execute(
         self, codebase: Codebase, prompt: str, subdirs_or_files: List[str]
-    ) -> Tuple[List[str], List[Any]]:
+    ) -> StrategyExecuteResult:
         prompt = f"""
         A file with this path is highly likely to contain content that matches the following criteria:
         <content_criterias>
@@ -833,7 +901,7 @@ class FilterDependencyByLLMStrategy(FilterByLLMStrategy[Dependency]):
     @override
     async def execute(
         self, codebase: Codebase, prompt: str, subdirs_or_files: List[str]
-    ) -> Tuple[List[str], List[Any]]:
+    ) -> StrategyExecuteResult:
         enhanced_prompt = f"""
         A dependency that matches the following criteria is highly likely to be relevant:
         <dependency_criteria>
@@ -973,7 +1041,7 @@ class FilterKeywordByVectorAndLLMStrategy(FilterByVectorAndLLMStrategy):
         codebase: Codebase,
         prompt: str,
         subdirs_or_files: List[str],
-    ) -> Tuple[List[str], List[Any]]:
+    ) -> StrategyExecuteResult:
         prompt = f"""
         A code chunk containing the specified keywords is highly likely to meet the following criteria:
         <content_criteria>
@@ -1051,7 +1119,7 @@ class AdaptiveFilterKeywordByVectorAndLLMStrategy(AdaptiveFilterByVectorAndLLMSt
         codebase: Codebase,
         prompt: str,
         subdirs_or_files: List[str],
-    ) -> Tuple[List[str], List[Any]]:
+    ) -> StrategyExecuteResult:
         prompt = f"""
         A code chunk containing the specified keywords is highly likely to meet the following criteria:
         <content_criteria>
@@ -1112,6 +1180,7 @@ class FilterSymbolByVectorAndLLMStrategy(FilterByVectorAndLLMStrategy):
         filtered_elements: List[Any],
         codebase: Codebase,
         subdirs_or_files: List[str],
+
     ) -> List[str]:
         file_paths = []
         for symbol in filtered_elements:
@@ -1127,7 +1196,7 @@ class FilterSymbolByVectorAndLLMStrategy(FilterByVectorAndLLMStrategy):
         codebase: Codebase,
         prompt: str,
         subdirs_or_files: List[str],
-    ) -> Tuple[List[str], List[Any]]:
+    ) -> StrategyExecuteResult:
         prompt = f"""
         requirement: A code chunk with this name is highly likely to meet the following criteria:
         <content_criteria>
@@ -1203,7 +1272,7 @@ class AdaptiveFilterSymbolByVectorAndLLMStrategy(AdaptiveFilterByVectorAndLLMStr
         codebase: Codebase,
         prompt: str,
         subdirs_or_files: List[str],
-    ) -> Tuple[List[str], List[Any]]:
+    ) -> StrategyExecuteResult:
         prompt = f"""
         requirement: A code chunk with this name is highly likely to meet the following criteria:
         <content_criteria>
@@ -1217,6 +1286,20 @@ class AdaptiveFilterSymbolByVectorAndLLMStrategy(AdaptiveFilterByVectorAndLLMStr
         return await super().execute(codebase, prompt, subdirs_or_files)
 
 
+class RecalledLineEntry(BaseModel):
+    """Pydantic model representing a recalled line entry with metadata."""
+    line_content: str = Field(description="The content of the recalled line")
+    symbol: Symbol = Field(description="Symbol object containing this line")
+    score: float = Field(description="Vector similarity score for this line")
+
+
+class VectorLineRecallResult(BaseModel):
+    """Pydantic model representing the result of manual vector recall."""
+    line_content: str = Field(description="The content of the recalled line")
+    line_index: int = Field(description="The original line index in the symbol")
+    similarity_score: float = Field(description="The normalized similarity score")
+
+
 @define
 class SymbolStruct:
     """Structure to represent a symbol and its metadata for intelligent filtering."""
@@ -1227,7 +1310,7 @@ class SymbolStruct:
     file_path: str           # File path for the symbol
 
 
-class IntelligentFilterStrategy(RecallStrategyExecutor):
+class FilterTopkLineByVectorAndLLMStrategy(RecallStrategyExecutor):
     """
     Intelligent filtering strategy that performs line-level vector recall within symbols,
     then uses LLM to judge and select the most relevant lines across all symbols.
@@ -1286,7 +1369,7 @@ class IntelligentFilterStrategy(RecallStrategyExecutor):
             logger.error(f"All retry attempts failed for line embeddings: {e}")
             return []
     
-    async def _vector_recall_topk(self, func_struct: SymbolStruct, query: str, k: int) -> List[Tuple[str, int, float]]:
+    async def _vector_recall_topk(self, func_struct: SymbolStruct, query: str, k: int) -> List[VectorLineRecallResult]:
         """
         Perform vector-based top-k recall for lines within a function using in-memory computation.
         
@@ -1296,14 +1379,14 @@ class IntelligentFilterStrategy(RecallStrategyExecutor):
             k: Number of top lines to return
             
         Returns:
-            List of tuples (line_content, line_index, similarity_score)
+            List of ManualVectorRecallResult objects
         """
         if not func_struct.vectors or not func_struct.lines:
             return []
         
         return await self._manual_vector_recall(func_struct, query, k)
     
-    async def _manual_vector_recall(self, func_struct: SymbolStruct, query: str, k: int) -> List[Tuple[str, int, float]]:
+    async def _manual_vector_recall(self, func_struct: SymbolStruct, query: str, k: int) -> List[VectorLineRecallResult]:
         """
         Fallback manual vector recall using numpy operations.
         """
@@ -1341,7 +1424,11 @@ class IntelligentFilterStrategy(RecallStrategyExecutor):
 
                     if original_idx >= 0:
                         normalized_score = (similarities[idx] + 1) / 2
-                        results.append((filtered_line, original_idx, normalized_score))
+                        results.append(VectorLineRecallResult(
+                            line_content=filtered_line,
+                            line_index=original_idx,
+                            similarity_score=normalized_score
+                        ))
             
             return results
             
@@ -1553,7 +1640,7 @@ Call the select_relevant_lines function with your analysis."""
                 return [], []
             
             # Step 2: Perform vector-based recall for each symbol and sort by similarity
-            all_recalled_lines = []
+            all_recalled_lines: List[RecalledLineEntry] = []
             print("Entering Step 2 - Vector recall for symbols")
             for symbol_struct in symbol_structs:
                 recalled_lines = await self._vector_recall_topk(
@@ -1563,12 +1650,10 @@ Call the select_relevant_lines function with your analysis."""
                 if recalled_lines:
                     # Store line candidates with metadata
                     for line_content, line_idx, score in recalled_lines:
-                        all_recalled_lines.append((
-                            line_content, 
-                            symbol_struct.symbol.name,
-                            symbol_struct.file_path,
-                            symbol_struct.symbol_id,
-                            score
+                        all_recalled_lines.append(RecalledLineEntry(
+                            line_content=line_content,
+                            symbol=symbol_struct.symbol,
+                            score=score
                         ))
             
             logger.info(f"Collected {len(all_recalled_lines)} line candidates from vector recall")
@@ -1578,13 +1663,14 @@ Call the select_relevant_lines function with your analysis."""
                 return [], []
             
             # Sort by vector similarity score (descending)
-            all_recalled_lines.sort(key=lambda x: x[4], reverse=True)
+            all_recalled_lines.sort(key=lambda x: x.score, reverse=True)
             logger.info("Sorted line candidates by vector similarity score")
             
             # Step 3: Optimized LLM processing with dynamic batch evaluation
             print("Entering Step 3 - Dynamic batch processing")
             selected_file_paths = set()
-            recalled_symbols = set()
+            recalled_symbols = [] 
+            recalled_symbol_ids = set()
             batch_size = 120
             
             # Process candidates in dynamic batches
@@ -1597,21 +1683,23 @@ Call the select_relevant_lines function with your analysis."""
             with tqdm(total=self.max_queries, desc="LLM batch queries", unit="query") as pbar:
                 while current_index < len(all_recalled_lines) and query_count < self.max_queries:
                     # Collect next batch of valid candidates
-                    batch_candidates = []
+                    batch_candidates:list[RecalledLineEntry] = []
                     
                     while len(batch_candidates) < batch_size and current_index < len(all_recalled_lines):
-                        line_content, symbol_name, file_path, symbol_id, score = all_recalled_lines[current_index]
+                        entry = all_recalled_lines[current_index]
                         current_index += 1
                         
                         # Skip if symbol already recalled
-                        if symbol_id in recalled_symbols:
+                        symbol_id = entry.symbol.id or f"{entry.symbol.name}_{entry.symbol.file.path}"
+                        if symbol_id in recalled_symbol_ids:
                             continue
                         
                         # Skip if file path already selected
+                        file_path = str(entry.symbol.file.path)
                         if file_path in selected_file_paths:
                             continue
                         
-                        batch_candidates.append((line_content, symbol_name, file_path, symbol_id, score))
+                        batch_candidates.append(entry)
                     
                     if not batch_candidates:
                         break
@@ -1619,7 +1707,7 @@ Call the select_relevant_lines function with your analysis."""
                     batch_count += 1
                     
                     # Prepare batch data for LLM judgment
-                    batch_data = [(line_content, symbol_name, file_path) for line_content, symbol_name, file_path, symbol_id, score in batch_candidates]
+                    batch_data = [(entry.line_content, entry.symbol.name, str(entry.symbol.file.path)) for entry in batch_candidates]
                     
                     # Get LLM judgment on this batch
                     selected_lines = await self._llm_recall_judgment(batch_data, prompt)
@@ -1628,11 +1716,13 @@ Call the select_relevant_lines function with your analysis."""
                     
                     # Mark selected symbols as recalled
                     for selected_line in selected_lines:
-                        for line_content, symbol_name, file_path, symbol_id, score in batch_candidates:
-                            if line_content == selected_line and symbol_id not in recalled_symbols:
-                                recalled_symbols.add(symbol_id)
+                        for entry in batch_candidates:
+                            file_path = str(entry.symbol.file.path)
+                            if entry.line_content == selected_line and symbol_id not in recalled_symbol_ids:
+                                recalled_symbols.append(entry.symbol)
+                                recalled_symbol_ids.add(symbol_id)
                                 selected_file_paths.add(file_path)
-                                logger.info(f"Selected symbol {symbol_name} from {file_path} (score: {score:.3f})")
+                                logger.info(f"Selected symbol {entry.symbol.name} from {file_path} (score: {entry.score:.3f})")
                                 break
                     
                     logger.info(f"Processed batch {batch_count}: Selected {len(selected_lines)} symbols from {len(batch_candidates)} candidates")
@@ -1641,7 +1731,11 @@ Call the select_relevant_lines function with your analysis."""
             print(f"Total selected file paths: {len(file_paths)}")
             logger.info(f"Intelligent filtering completed. Selected {len(file_paths)} files from {len(recalled_symbols)} symbols.")
             
-            return file_paths, []
+            return StrategyExecuteResult(
+                file_paths=file_paths,
+                elements=deduplicate_elements(recalled_symbols),
+                llm_results=[]
+            )
             
         except Exception as e:
             logger.error(f"Error in {strategy_name} strategy: {e}")
@@ -1667,7 +1761,7 @@ class StrategyFactory:
             RecallStrategy.FILTER_SYMBOL_BY_VECTOR_AND_LLM: FilterSymbolByVectorAndLLMStrategy,
             RecallStrategy.ADAPTIVE_FILTER_KEYWORD_BY_VECTOR_AND_LLM: AdaptiveFilterKeywordByVectorAndLLMStrategy,
             RecallStrategy.ADAPTIVE_FILTER_SYMBOL_BY_VECTOR_AND_LLM: AdaptiveFilterSymbolByVectorAndLLMStrategy,
-            RecallStrategy.INTELLIGENT_FILTER: IntelligentFilterStrategy,
+            RecallStrategy.FILTER_TOPK_LINE_BY_VECTOR_AND_LLM: FilterTopkLineByVectorAndLLMStrategy,
         }
 
         if strategy not in strategy_map:

--- a/coderetrx/static/codebase/__init__.py
+++ b/coderetrx/static/codebase/__init__.py
@@ -1,4 +1,4 @@
-from .codebase import (
+coderetrx/impl/default/smart_codebase.pyfrom .codebase import (
     Codebase,
     File,
     FileType,
@@ -10,6 +10,7 @@ from .codebase import (
     CodeChunk,
     ChunkType,
     CodeHunk,
+    CodeLine,
 )
 from .models import (
     CodebaseModel,
@@ -39,6 +40,7 @@ __all__ = [
     "CodeChunk",
     "ChunkType",
     "CodeHunk",
+    "CodeLine",
     "IDXSupportedLanguage",
     "IDXSupportedTag",
     "BUILTIN_CRYPTO_LIBS",

--- a/coderetrx/static/codebase/__init__.py
+++ b/coderetrx/static/codebase/__init__.py
@@ -1,4 +1,4 @@
-coderetrx/impl/default/smart_codebase.pyfrom .codebase import (
+from .codebase import (
     Codebase,
     File,
     FileType,

--- a/coderetrx/static/codebase/codebase.py
+++ b/coderetrx/static/codebase/codebase.py
@@ -712,11 +712,13 @@ class CallGraphEdge:
         return model.to_edge(codebase)
 
 
-class CodeLine:
+class CodeLine(BaseModel):
     """Pydantic model representing a code line entry with metadata."""
     line_content: str = Field(description="The content of the code line")
     symbol: Symbol = Field(description="Symbol object containing this line")
     score: float = Field(description="Vector similarity score for this line")
+    
+    @classmethod
     def new(
         cls, line_content: str, symbol: Symbol, score: float = 0.0
     ) -> "CodeLine":

--- a/coderetrx/static/codebase/codebase.py
+++ b/coderetrx/static/codebase/codebase.py
@@ -714,6 +714,8 @@ class CallGraphEdge:
 
 class CodeLine(BaseModel):
     """Pydantic model representing a code line entry with metadata."""
+    model_config = {"arbitrary_types_allowed": True}
+    
     line_content: str = Field(description="The content of the code line")
     symbol: Symbol = Field(description="Symbol object containing this line")
     score: float = Field(description="Vector similarity score for this line")

--- a/coderetrx/utils/embedding.py
+++ b/coderetrx/utils/embedding.py
@@ -64,7 +64,7 @@ async def embed_batch_with_retry(batch):
         raise  # Re-raise to trigger retry
 
 
-def create_documents_embedding(docs: List[str], batch_size=100, max_concurrency=5):
+def create_documents_embedding(docs: List[str], batch_size=100, max_concurrency=15):
     """Create embeddings for a list of documents with batching and concurrency."""
     # Prepare batches
     kwargs_list = [
@@ -105,6 +105,7 @@ class SimilaritySearcher:
         texts: List[str],
         embeddings: Optional[List[List[float]]] = None,
         use_cache: bool = True,
+        metadatas: Optional[List[dict]] = None,
     ) -> None:
         """
         Initialize the SimilaritySearcher.
@@ -114,10 +115,12 @@ class SimilaritySearcher:
             texts: List of texts to be indexed.
             embeddings: Optional precomputed embeddings corresponding to the texts.
             use_cache: Whether to use cached collection if available.
+            metadatas: Optional metadata list corresponding to each text.
         """
         self.texts = texts
         self.name = name
         self.use_cache = use_cache
+        self.metadatas = metadatas
 
         # Check or create Chroma collection
 
@@ -129,14 +132,24 @@ class SimilaritySearcher:
                 )
                 use_cache = False
             else:
-                logger.info(
-                    f"Using existing ChromaDB collection '{name}' with {collection.count()} documents"
-                )
+                # Determine content type from collection name for better cache message
+                if "symbol_names" in name:
+                    content_type = "symbol names"
+                elif "symbol_contents" in name:
+                    content_type = "symbol contents"
+                elif "symbol_codelines" in name:
+                    content_type = "code lines"
+                elif "keywords" in name:
+                    content_type = "keywords"
+                else:
+                    content_type = "documents"
+                
+                logger.info(f"Using cached {content_type} from ChromaDB collection '{name}' ({collection.count()} items)")
 
             if not use_cache:
                 chromadb_client.delete_collection(name)
-                collection = chromadb_client.get_collection(name)
-        except:
+                collection = chromadb_client.create_collection(name, metadata={"hnsw:space": "cosine"})
+        except Exception as e:
             logger.info(f"Creating new ChromaDB collection: '{name}'")
             collection = chromadb_client.create_collection(
                 name, metadata={"hnsw:space": "cosine"}
@@ -150,30 +163,53 @@ class SimilaritySearcher:
                 f"Adding {len(texts)} documents to ChromaDB collection '{name}'"
             )
             batch_size = 1000
-            for idx in tqdm(range(0, len(texts), batch_size), desc="Adding documents to ChromaDB"):
+            # Determine content type from collection name for better progress description
+            if "symbol_names" in name:
+                content_type = "symbol names"
+            elif "symbol_contents" in name:
+                content_type = "symbol contents"
+            elif "symbol_codelines" in name:
+                content_type = "code lines"
+            elif "keywords" in name:
+                content_type = "keywords"
+            else:
+                content_type = "documents"
+            
+            for idx in tqdm(range(0, len(texts), batch_size), desc=f"Adding {content_type} to ChromaDB"):
                 text_batch = texts[idx : idx + batch_size]
+                metadata_batch = metadatas[idx : idx + batch_size] if metadatas else None
                 if embeddings:
                     embedding_batch = embeddings[idx : idx + batch_size]
-                    self._add_texts_with_embeddings(text_batch, embedding_batch)
+                    self._add_texts_with_embeddings(text_batch, embedding_batch, metadata_batch)
                 else:
-                    self.collection.add(
-                        documents=text_batch,
-                        embeddings=create_documents_embedding(text_batch),
-                        ids=[str(idx + i) for i in range(len(text_batch))],
-                    )
+                    add_kwargs = {
+                        "documents": text_batch,
+                        "embeddings": create_documents_embedding(text_batch),
+                        "ids": [str(idx + i) for i in range(len(text_batch))],
+                    }
+                    if metadata_batch:
+                        add_kwargs["metadatas"] = metadata_batch
+                    self.collection.add(**add_kwargs)
 
     def _add_texts_with_embeddings(
-        self, texts: List[str], embeddings: List[List[float]]
+        self, texts: List[str], embeddings: List[List[float]], metadatas: Optional[List[dict]] = None
     ):
         """Add texts with precomputed embeddings to the collection."""
         if len(texts) != len(embeddings):
             raise ValueError("Number of texts must match number of embeddings")
+        
+        if metadatas and len(texts) != len(metadatas):
+            raise ValueError("Number of texts must match number of metadatas")
 
-        self.collection.add(
-            documents=texts,
-            embeddings=embeddings,  # type: ignore
-            ids=[str(i) for i in range(len(texts))],
-        )
+        add_kwargs = {
+            "documents": texts,
+            "embeddings": embeddings,
+            "ids": [str(i) for i in range(len(texts))],
+        }
+        if metadatas:
+            add_kwargs["metadatas"] = metadatas
+        
+        self.collection.add(**add_kwargs)
 
     def add_texts(
         self, texts: List[str], embeddings: Optional[List[List[float]]] = None
@@ -240,5 +276,55 @@ class SimilaritySearcher:
         result = list(zip(documents, normalized_scores))
         logger.info(
             f"Found {len(result)} matching documents in collection '{self.name}'"
+        )
+        return result
+
+    def search_with_filter(self, query: str, where: dict, k: int = 10):
+        """
+        Search for the most similar documents to the query with metadata filtering.
+
+        Args:
+            query: Query string.
+            where: Metadata filter criteria.
+            k: Number of top results to return.
+
+        Returns:
+            A list of tuples (document, normalized_score).
+        """
+
+        def normalize_score(raw_score, metric="cosine", max_distance=1.0):
+            """
+            Normalize raw similarity or distance score to [0, 1].
+            """
+            if metric == "cosine":
+                return (raw_score + 1) / 2
+            elif metric == "euclidean":
+                return max(0, 1 - (raw_score / max_distance))
+            else:
+                raise ValueError(f"Unsupported metric: {metric}")
+
+        logger.info(
+            f"Performing filtered similarity search in collection '{self.name}' with k={k}, filter={where}"
+        )
+        query_embedding = create_documents_embedding([query])[0]
+        results = self.collection.query(
+            query_embeddings=[query_embedding], 
+            where=where,
+            n_results=k
+        )
+
+        documents = results["documents"][0]  # type: ignore
+        distances = results["distances"][0]  # type: ignore
+        assert documents is not None
+        assert distances is not None
+
+        # Normalize distances or scores to [0, 1]
+        normalized_scores = [
+            normalize_score(-distance, metric="cosine") for distance in distances
+        ]
+
+        result = list(zip(documents, normalized_scores))
+        logger.info(
+            f"Found {len(result)} matching documents in filtered collection '{self.name}'"
         )
         return result

--- a/scripts/code_retriever.py
+++ b/scripts/code_retriever.py
@@ -25,7 +25,7 @@ import argparse
 import sys
 import time
 
-logging.basicConfig(level=logging.ERROR)
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class CodeRetriever:
@@ -67,6 +67,7 @@ class CodeRetriever:
         os.environ["KEYWORD_EMBEDDING"] = "true"
         os.environ["SYMBOL_NAME_EMBEDDING"] = "true"
         os.environ["SYMBOL_CONTENT_EMBEDDING"] = "true"
+        os.environ["SYMBOL_CODELINE_EMBEDDING"] = "true"
         
         cache_root = Path(__file__).parent.parent / ".cache"
         chroma_dir = cache_root / "chroma"
@@ -183,6 +184,9 @@ class CodeRetriever:
                 initial_cost = 0.0
                 initial_input_tokens = 0
                 initial_output_tokens = 0
+            
+            result = []
+            llm_output = []
             
             try:
                 # Create settings with appropriate llm_call_mode
@@ -347,24 +351,79 @@ class CodeRetriever:
         if not Path(output_file).is_absolute():
             output_file = code_report_dir / output_file
         
-        def make_serializable(obj):
+        def make_serializable(obj, seen=None):
             """Convert objects to JSON-serializable format"""
-            if hasattr(obj, 'to_json'):
-                return obj.to_json()
-            elif hasattr(obj, 'model_dump'):
-                return obj.model_dump()
-            elif hasattr(obj, '__dict__'):
-                return {k: make_serializable(v) for k, v in obj.__dict__.items()}
-            elif isinstance(obj, (list, tuple)):
-                return [make_serializable(item) for item in obj]
-            elif isinstance(obj, dict):
-                return {k: make_serializable(v) for k, v in obj.items()}
-            else:
+            if seen is None:
+                seen = set()
+            
+            # Handle None values
+            if obj is None:
+                return None
+            
+            # Handle primitive types first
+            if isinstance(obj, (str, int, float, bool)):
+                return obj
+            
+            # Prevent circular references
+            obj_id = id(obj)
+            if obj_id in seen:
+                return f"<circular reference to {type(obj).__name__}>"
+            
+            # Handle CodeMapFilterResult specifically
+            if hasattr(obj, '__class__') and obj.__class__.__name__ == 'CodeMapFilterResult':
+                # Directly return dictionary without recursion to avoid circular reference
+                result_value = obj.result
+                # Handle result value carefully
+                if isinstance(result_value, (str, int, float, bool, type(None))):
+                    serialized_result = result_value
+                else:
+                    serialized_result = str(result_value)
+                
+                return {
+                    'index': obj.index,
+                    'reason': str(obj.reason),
+                    'result': serialized_result
+                }
+            
+            seen.add(obj_id)
+            
+            try:
+                # Handle other Pydantic models
+                if hasattr(obj, 'model_dump'):
+                    try:
+                        return obj.model_dump()
+                    except Exception:
+                        # Fallback to dict conversion
+                        return {k: make_serializable(v, seen) for k, v in obj.__dict__.items()}
+                
+                # Handle objects with to_json method
+                if hasattr(obj, 'to_json'):
+                    try:
+                        return obj.to_json()
+                    except Exception:
+                        # Fallback to dict conversion
+                        return {k: make_serializable(v, seen) for k, v in obj.__dict__.items()}
+                
+                # Handle lists and tuples
+                if isinstance(obj, (list, tuple)):
+                    return [make_serializable(item, seen) for item in obj]
+                
+                # Handle dictionaries
+                if isinstance(obj, dict):
+                    return {k: make_serializable(v, seen) for k, v in obj.items()}
+                
+                # Handle objects with __dict__
+                if hasattr(obj, '__dict__'):
+                    return {k: make_serializable(v, seen) for k, v in obj.__dict__.items()}
+                
+                # Final fallback - try JSON serialization
                 try:
                     json.dumps(obj)
                     return obj
                 except (TypeError, ValueError):
                     return str(obj)
+            finally:
+                seen.discard(obj_id)
         
         serializable_codes = make_serializable(codes)
         


### PR DESCRIPTION
This PR mainly adds the following new features:
1. Add an option to enable the use of coarse recall returned elements to perform the refined filtering
2. Implements a dedicated similarity searcher for code lines

This PR also makes the following fixes:
1. Optimize return value handling by converting tuples to Pydantic models
2. Renames IntellectualStrategy to FilterTopkLineByVectorAndLLMStrategy for better clarity
4. Removes the self-implemented searcher from FilterTopkLineByVectorAndLLMStrategy